### PR TITLE
Remove redefines caused by duplicate macros

### DIFF
--- a/utils/ANLEra_other.cfg
+++ b/utils/ANLEra_other.cfg
@@ -1,8 +1,6 @@
 #textdomain wesnoth-ANLEra
 
-#define SPECIAL_NOTES_INSPIRE
-_" The presence of this unit inspires own units next to it to deal more damage in combat, though this only applies to units of lower or equal level."#enddef
-
+#ifver WESNOTH_VERSION < 1.13.2
 #define ABILITY_INSPIRE_LEVEL_1
     # Canned definition of the Inspire (level 1) ability to be included in an
     # [abilities] clause.
@@ -131,6 +129,19 @@ _" The presence of this unit inspires own units next to it to deal more damage i
         [/affect_adjacent]
     [/leadership]
 #enddef
+#else
+#define ABILITY_INSPIRE_LEVEL_1
+    {ABILITY_INSPIRE}
+#enddef
+#define ABILITY_INSPIRE_LEVEL_2
+    {ABILITY_INSPIRE}
+#enddef
+#define ABILITY_INSPIRE_LEVEL_3
+    {ABILITY_INSPIRE}
+#enddef
+#endif
+
+
 #textdomain wesnoth-ANLEra
 #define TERRAIN
 terrain="Ss,Sm,Gd,Gll,Rb,Rr,Rrc,Rp,Ai,Aa,Dd,Ds,Gg^Do,Gg^Dr,Dd^Dc,Gg^Efm,Gg^Es,Gg^Em,Gg^Emf,Gg^Edp,Gg^Edpp,Gg^Wm,Gg^Ecf,Gg^Eff,Gg^Esd,Gg^Ewl,Gg^Ewf,Gg^Fet,Gg^Fetd,Gg^Ft,Gg^Ftr,Gg^Ftd,Gg^Ftp,Gg^Fts,Gg^Fp,Gg^Fpa,Gg^Fds,Gg^Fdf,Iwr,Gg^Ii,Uue,Urb,Ur,Gg^Uf,Gg^Ufi"               

--- a/utils/ANLEra_other.cfg
+++ b/utils/ANLEra_other.cfg
@@ -141,101 +141,17 @@
 #enddef
 #endif
 
-
 #textdomain wesnoth-ANLEra
 #define TERRAIN
-terrain="Ss,Sm,Gd,Gll,Rb,Rr,Rrc,Rp,Ai,Aa,Dd,Ds,Gg^Do,Gg^Dr,Dd^Dc,Gg^Efm,Gg^Es,Gg^Em,Gg^Emf,Gg^Edp,Gg^Edpp,Gg^Wm,Gg^Ecf,Gg^Eff,Gg^Esd,Gg^Ewl,Gg^Ewf,Gg^Fet,Gg^Fetd,Gg^Ft,Gg^Ftr,Gg^Ftd,Gg^Ftp,Gg^Fts,Gg^Fp,Gg^Fpa,Gg^Fds,Gg^Fdf,Iwr,Gg^Ii,Uue,Urb,Ur,Gg^Uf,Gg^Ufi"               
+    terrain="Ss,Sm,Gd,Gll,Rb,Rr,Rrc,Rp,Ai,Aa,Dd,Ds,Gg^Do,Gg^Dr,Dd^Dc,Gg^Efm,Gg^Es,Gg^Em,Gg^Emf,Gg^Edp,Gg^Edpp,Gg^Wm,Gg^Ecf,Gg^Eff,Gg^Esd,Gg^Ewl,Gg^Ewf,Gg^Fet,Gg^Fetd,Gg^Ft,Gg^Ftr,Gg^Ftd,Gg^Ftp,Gg^Fts,Gg^Fp,Gg^Fpa,Gg^Fds,Gg^Fdf,Iwr,Gg^Ii,Uue,Urb,Ur,Gg^Uf,Gg^Ufi"
 #enddef
-#define ANLEra_WORK
-    [event]
-        name=prestart
 
-        # Players
-        {SET_SIDE_VARIABLES 1}
-        {SET_SIDE_VARIABLES 2}
-        {SET_SIDE_VARIABLES 3}
-        {SET_SIDE_VARIABLES 4}
-
-        {ANL_HELP}
-        {WORKER_OPTIONS "Peasant,Walking Corpse,ANLElvish Civilian,Drake Worker,ANLDwarvish Miner"}
-        {RESEARCH_OPTIONS "Mage,Red Mage,White Mage,Mage of Light,Silver Mage,Arch Mage,Great Mage,ANLDwarvish Witness,ANLDwarvish Annalist,ANLDwarvish Loremaster,Elvish Shaman,Elvish Druid,Elvish Sorceress,Elvish Shyde,Elvish Enchantress,Elvish Sylph,Dark Adept,Dark Sorcerer,Lich,Necromancer"}
-        {LEADER_OPTIONS}
-    [/event]
-
-    # Auto-studying
-
-    {AUTO_STUDYING "Mage,Red Mage,White Mage,Mage of Light,Silver Mage,Arch Mage,Great Mage,ANLDwarvish Witness,ANLDwarvish Annalist,ANLDwarvish Loremaster,Elvish Shaman,Elvish Druid,Elvish Sorceress,Elvish Shyde,Elvish Enchantress,Elvish Sylph,Dark Adept,Dark Sorcerer,Lich,Necromancer"}
-
-    # Research complete messages
-
-    [event]
-        name=side turn
-        first_time_only=no
-        [if]
-            [variable]
-                name=side_number
-                less_than_equal_to=4
-            [/variable]
-
-            [then]
-                {FARMING_RESEARCH_COMPLETE}
-                {MINING_RESEARCH_COMPLETE}
-                {WARFARE_RESEARCH_COMPLETE}
-            [/then]
-        [/if]
-    [/event]
-
-    # Remove working status from any working units when starting a turn
-
-    [event]
-        name=side turn
-        first_time_only=no
-
-        [store_unit]
-            [filter]
-                side=$side_number
-
-                [filter_wml]
-                    [status]
-                        worked_this_turn=yes
-                    [/status]
-                [/filter_wml]
-            [/filter]
-
-            kill=yes
-            variable=this_side_workers
-        [/store_unit]
-
-        {FOREACH this_side_workers i}
-            [clear_variable]
-                name=this_side_workers[$i].status.worked_this_turn
-            [/clear_variable]
-
-            [unstore_unit]
-                variable=this_side_workers[$i]
-            [/unstore_unit]
-        {NEXT i}
-
-        [clear_variable]
-            name=this_side_workers
-        [/clear_variable]
-    [/event]
-
-    # Auto-working
-
-    {AUTO_FARMING "Peasant,Walking Corpse,ANLElvish Civilian,Drake Worker,ANLDwarvish Miner"}
-    {AUTO_MINING "Peasant,Walking Corpse,ANLElvish Civilian,Drake Worker,ANLDwarvish Miner"}
-
-#enddef
 #define RANDOM_ANLEra
-[variable]
-name=number	
-value=
-[random]
-value=1,2
-[/random]
-[/variable]
+    [variable]
+        name=number
+        value=
+        [random]
+            value=1,2
+        [/random]
+    [/variable]
 #enddef
-
-
-

--- a/utils/animation.cfg
+++ b/utils/animation.cfg
@@ -171,34 +171,6 @@
     [/leading_anim]
 #enddef
 
-#define TEG_MISSILE_FRAME_BOLAS
-    missile_start_time=-200
-    [missile_frame]
-        duration=50
-        offset=-0.1~0.125
-        image="projectiles/bolas-n.png"
-        image_diagonal="projectiles/bolas-ne.png"
-    [/missile_frame]
-    [missile_frame]
-        duration=50
-        offset=0.125~0.350
-        image="projectiles/bolas-n.png"
-        image_diagonal="projectiles/bolas-ne.png"
-    [/missile_frame]
-    [missile_frame]
-        duration=50
-        offset=0.350~0.575
-        image="projectiles/bolas-n.png"
-        image_diagonal="projectiles/bolas-ne.png"
-    [/missile_frame]
-    [missile_frame]
-        duration=50
-        offset=0.575~0.8
-        image="projectiles/bolas-n.png"
-        image_diagonal="projectiles/bolas-ne.png"
-    [/missile_frame]
-#enddef
-
 #define TEG_ATTACK_ANIMATION_NAME START_IMAGE MIDTH_IMAGE CENTRAL_IMAGE HIT_SOUND MISS_SOUND NAME
     #coded for wose for melee attacks
     [attack_anim]


### PR DESCRIPTION
As for the last commit, the current version of t the macro obviously doesn't belong to utils/abilities, but I leave it up to you to find a new location for it, other isn't the best name either.