### PR TITLE
Disallow using ANLEra with the default ANL scenario.

### DIFF
--- a/ANLEra.cfg
+++ b/ANLEra.cfg
@@ -16,6 +16,7 @@
     {TURNS_OVER_ADVANTAGE}
     [event]
         name=prestart
+        disallow_scenario=multiplayer_A_New_Land
 
         # Players
 		


### PR DESCRIPTION
I looked a few days ago what is different between the default version (don't remember if 1.12 or 1.13)of the scenario and your one.
- the [side] tags
- you use extended terrain matching
- removing of the included macros, since they cause problems.

A note in the _server.pbl to use about using it with the modifed version would maybe be good.

Can I ask you to make a PR to mainline with the extended terrain matching? I think it would be good.