### PR TITLE
Edited the scenarios

### DIFF
--- a/scenarios/4p_A_New_Land.cfg
+++ b/scenarios/4p_A_New_Land.cfg
@@ -3,20 +3,24 @@
     id=ANLMap
     name= _ "4p — ANLEra A New Land"
     map_data="{~add-ons/ANLEra/maps/Newland.map}"
-    description= _ "This 4p survival scenario allows you to construct buildings and terraform the land. Use map settings. The recommended starting gold is 100. Edited by Robertdebrus"
+    #textdomain wesnoth-anl
+    description= _ "This 4p survival scenario allows you to construct buildings and terraform the land. Use map settings. The recommended starting gold is 100." + "
+" +
+        #textdomain wesnoth-ANLEra
+        _ "Edited by Robertdebrus for use with A New Land Era."
+    #textdomain wesnoth-anl
     experience_modifier=70%
     turns=unlimited
-    #textdomain wesnoth-macros
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}
-    #textdomain wesnoth-ANLEra
+
+    # This demands the scenario to be played with A New Land Era
+    allow_era=Anewlandera
+
     # ------------------------------------------------------
     # Include ANL macros
     # ------------------------------------------------------
-    #   {~add-ons/ANLEra/utils}
-    #   {~add-ons/ANLEra/maps}
-    #   {~add-ons/ANLEra/units}
-    #   {~add-ons/ANLEra/images}
+    # Macros are included from the era or modification
 
     # ------------------------------------------------------
     # Story & Objectives
@@ -52,6 +56,7 @@
         canrecruit=yes
         controller=human
         team_name=1
+        income=2
         user_team_name= _ "teamname^Team 1"
         team_lock=yes
         income_lock=yes
@@ -84,7 +89,6 @@
         village_gold=2
         shroud=no
         fog=yes
-        recruit=Peasant,Mage
     [/side]
 
     [side]

--- a/scenarios/4p_The_Wall.cfg
+++ b/scenarios/4p_The_Wall.cfg
@@ -10,16 +10,16 @@
     random_starting_time=no
     victory_when_enemies_defeated=yes
 
-    #textdomain wesnoth-macros
     {DEFAULT_SCHEDULE}
     {DEFAULT_MUSIC_PLAYLIST}
-    #textdomain wesnoth-ANLEra
 
     [event]
         name="start"
         [objectives]
             side=0
+            #textdomain wesnoth-anl
             summary="<small>" + _ "Right-click on your leader during your turn for help" + "</small>" # wmllint: no spellcheck
+            #textdomain wesnoth-ANLEra
             [objective]
                 description= _ "Defeat All Enemy Leaders"
                 condition=win
@@ -31,32 +31,31 @@
         controller="human"
         fog=no
         gold=110
-        hidden=no
         income=2
-        no_leader=no
+#ifver WESNOTH_VERSION < 1.13.1
         share_maps=no
         share_view=no
+#else
+        share_vision=none
+#endif
         shroud=yes
+        income=2
         side=1
         team_name=1
-        user_team_name=1
+        #textdomain wesnoth-multiplayer
+        user_team_name= _ "teamname^West"
+        #textdomain wesnoth-ANLEra
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-1"
-            name="Owan"
+            name= _ "Owan"
             type="Peasant"
-            unrenamable=no
             x=3
             y=2
         [/unit]
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-2"
-            name="Aethubry"
+            name= _ "Aethubry"
             type="Peasant"
-            unrenamable=no
             x=1
             y=3
         [/unit]
@@ -65,32 +64,30 @@
         controller="human"
         fog=no
         gold=110
-        hidden=no
         income=2
-        no_leader=no
+#ifver WESNOTH_VERSION < 1.13.1
         share_maps=no
         share_view=no
+#else
+        share_vision=none
+#endif
         shroud=yes
         side=2
         team_name=2
-        user_team_name=2
+        #textdomain wesnoth-multiplayer
+        user_team_name= _ "teamname^East"
+        #textdomain wesnoth-ANLEra
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-3"
-            name="Blygwyn"
+            name= _ "Blygwyn"
             type="Peasant"
-            unrenamable=no
             x=44
             y=31
         [/unit]
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-4"
-            name="Midoc"
+            name= _ "Midoc"
             type="Peasant"
-            unrenamable=no
             x=42
             y=32
         [/unit]
@@ -99,32 +96,30 @@
         controller="human"
         fog=no
         gold=110
-        hidden=no
         income=2
-        no_leader=no
+#ifver WESNOTH_VERSION < 1.13.1
         share_maps=no
         share_view=no
+#else
+        share_vision=none
+#endif
         shroud=yes
         side=3
         team_name=2
-        user_team_name=2
+        #textdomain wesnoth-multiplayer
+        user_team_name= _ "teamname^East"
+        #textdomain wesnoth-ANLEra
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-5"
-            name="Rhygwyddryn"
+            name= _ "Rhygwyddryn"
             type="Peasant"
-            unrenamable=no
             x=42
             y=1
         [/unit]
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-6"
-            name="Blyn"
+            name= _ "Blyn"
             type="Peasant"
-            unrenamable=no
             x=42
             y=3
         [/unit]
@@ -133,32 +128,30 @@
         controller="human"
         fog=no
         gold=110
-        hidden=no
         income=2
-        no_leader=no
+#ifver WESNOTH_VERSION < 1.13.1
         share_maps=no
         share_view=no
+#else
+        share_vision=none
+#endif
         shroud=yes
         side=4
         team_name=1
-        user_team_name=1
+        #textdomain wesnoth-multiplayer
+        user_team_name= _ "teamname^West"
+        #textdomain wesnoth-ANLEra
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-7"
-            name="Sec"
+            name= _ "Sec"
             type="Peasant"
-            unrenamable=no
             x=1
             y=31
         [/unit]
         [unit]
-            canrecruit=no
-            extra_recruit=""
             id="Peasant-8"
-            name="Gwyn"
+            name= _ "Gwyn"
             type="Peasant"
-            unrenamable=no
             x=3
             y=33
         [/unit]


### PR DESCRIPTION
Restrict other Eras from being used with the default map, because they use different recruits.
However, this does also forbid the case of using another era but the modification instead.

Didn't add this to the alternative map, since you start there with two Peasants. You can't recruit new ones though if you choose e.g. Ageless Era.

Also some other changes.