### PR TITLE
Bring back Merfolk universities

### DIFF
--- a/utils/buildings/buildings_merfolk.cfg
+++ b/utils/buildings/buildings_merfolk.cfg
@@ -60,11 +60,24 @@
         {BUILD_SOUND_1}
     )}
     {ANL_BUILD_VILLAGE "terrain/village/swamp-merfolk-tile.png" _"Build Village" 17 Vm (
-        {ANL_SHOW_IF ("ANLEra Merman Citizen") "S*"}
+        {ANL_SHOW_IF ("ANLEra Merman Citizen") "S*,!,Sm,!"}
     ) (
         {BUILD_SOUND_1}
     )}
 
+    # Build University
+    {ANL_TERRAFORM "terrain/village/swamp-merfolk-tile.png" _"Establish University" 14 () (
+        {ANL_SHOW_IF ("ANLEra Merman Citizen") "*^Vm,!,Sm^Vm,!"}
+    ) (
+        {MODIFY_TERRAIN "Sm^Vm" $x1 $y1}
+        {BUILD_SOUND_2}
+    )}
+    # special case that there is Sm terrain on the map
+    {ANL_BUILD_VILLAGE "terrain/village/swamp-merfolk-tile.png" _"Establish University" 32 Vm (
+        {ANL_SHOW_IF ("ANLEra Merman Citizen") "Sm"}
+    ) (
+        {BUILD_SOUND_2}
+    )}
     # ------------------------------------------------
     # CASTLE
 


### PR DESCRIPTION
Works around the problem of Sm terrain by allowing to build an university there directly.
The other way would be to transform base terrain when building a village on Sm, to … maybe not Ss, it's a visual question.

I also added earlier that the can build on D* terrain, that fits visually.
Could have lower prices though… what would be fair?

Edit: To clarify, ANL_BUILD_VILLAGE is a shortcut to ANL_TERRAFORM, and the later is used once because the former only transforms overlays.